### PR TITLE
Lhfit highsignal gaussian approximation

### DIFF
--- a/lstchain/io/lstcontainers.py
+++ b/lstchain/io/lstcontainers.py
@@ -117,7 +117,7 @@ class DL1ParametersContainer(Container):
     trigger_time = Field(None, "trigger time")
 
     lhfit_call_status = Field(None, "Status of the processing of the event "
-                            "by the LH fit method")
+                              "by the LH fit method")
 
     # info not available in data
     #num_trig_pix = Field(None, "Number of trigger groups (sectors) listed")

--- a/lstchain/reco/r0_to_dl1.py
+++ b/lstchain/reco/r0_to_dl1.py
@@ -65,6 +65,7 @@ from ..pointing import PointingPosition
 from ..io.io import dl1_params_lstcam_key
 
 logger = logging.getLogger(__name__)
+logger.setLevel(DEBUG)
 
 
 __all__ = [
@@ -624,7 +625,7 @@ def r0_to_dl1(
                                          custom_config=config,
                                          use_main_island=True)
                 except HillasParameterizationError:
-                    logging.exception(
+                    logger.exception(
                         'HillasParameterizationError in get_dl1()'
                     )
 
@@ -653,9 +654,9 @@ def r0_to_dl1(
                                     dl1_filled.lhfit_call_status = "Processed"
                                 except Exception as err:
                                     dl1_filled.lhfit_call_status = "Not processed : Error in function"
-                                    logging.exception("Unexpected error encountered in : get_dl1_lh_fit()")
-                                    logging.exception(err.__class__)
-                                    logging.exception(err)
+                                    logger.exception("Unexpected error encountered in : get_dl1_lh_fit()")
+                                    logger.exception(err.__class__)
+                                    logger.exception(err)
                                     raise
                             else:
                                 dl1_filled.lhfit_call_status = "Not processed : Saturated"

--- a/lstchain/reco/r0_to_dl1.py
+++ b/lstchain/reco/r0_to_dl1.py
@@ -665,7 +665,6 @@ def r0_to_dl1(
                                                             + str(dl1_filled['n_pixels']))
                     else:
                         dl1_filled.lhfit_call_status = "Not active"
-                    )
 
                 if not is_simu:
                     # GPS + WRS + UCTS is now working in its nominal configuration.

--- a/lstchain/reco/r0_to_dl1.py
+++ b/lstchain/reco/r0_to_dl1.py
@@ -636,7 +636,7 @@ def r0_to_dl1(
 
                             is_saturated = np.any(image > config['lh_fit_config']['n_peaks'])
 
-                            if not is_saturated:
+                            if True: #not is_saturated: # temporary for testing only
                                 # rejects computationnally expensive events which would
                                 # be poorly estimated with the selected value of n_peak
                                 # TODO : improve to not reject events

--- a/lstchain/reco/r0_to_dl1.py
+++ b/lstchain/reco/r0_to_dl1.py
@@ -65,7 +65,6 @@ from ..pointing import PointingPosition
 from ..io.io import dl1_params_lstcam_key
 
 logger = logging.getLogger(__name__)
-logger.setLevel(DEBUG)
 
 
 __all__ = [

--- a/lstchain/reco/reconstructor.py
+++ b/lstchain/reco/reconstructor.py
@@ -18,9 +18,11 @@ from lstchain.visualization.camera import display_array_camera
 logger = logging.getLogger(__name__)
 logger.setLevel(DEBUG)
 
+
 class DL0Fitter(ABC):
     """
-        Base class for the extraction of DL1 parameters from R1 events using a log likelihood minimisation method.
+        Base class for the extraction of DL1 parameters from R1 events
+        using a log likelihood minimisation method.
 
     """
 
@@ -60,9 +62,11 @@ class DL0Fitter(ABC):
             crosstalk: float
                 Probability of a photo-electron to interact twice in a pixel
             sigma_space: float
-                Size of the region over which the likelihood needs to be estimated in number of standard deviation away from the center of the spatial model
+                Size of the region over which the likelihood needs to be estimated
+                in number of standard deviation away from the center of the spatial model
             sigma_time: float
-                Time window around the peak of signal over which to compute the likelihood in number of temporal width of the signal
+                Time window around the peak of signal over which to compute
+                the likelihood in number of temporal width of the signal
             time_before_shower: float
                 Duration before the start of the signal which is not ignored
             time_after_shower:
@@ -145,7 +149,6 @@ class DL0Fitter(ABC):
 
         pass
 
-
     def __str__(self):
 
         str = 'Start parameters :\n\t{}\n'.format(self.start_parameters)
@@ -190,7 +193,7 @@ class DL0Fitter(ABC):
 
                 for key, val in self.bound_parameters.items():
 
-                    bounds_params['limit_'+ key] = val
+                    bounds_params['limit_' + key] = val
 
             for key in self.names_parameters:
 
@@ -291,7 +294,7 @@ class DL0Fitter(ABC):
         return np.sum(llh)
 
     def plot_1dlikelihood(self, parameter_name, axes=None, size=1000,
-                        x_label=None, invert=False):
+                          x_label=None, invert=False):
 
         key = parameter_name
 
@@ -430,7 +433,7 @@ class DL0Fitter(ABC):
 
     def plot_likelihood(self, parameter_1, parameter_2=None,
                         axes=None, size=100,
-                          x_label=None, y_label=None):
+                        x_label=None, y_label=None):
 
         if parameter_2 is None:
 
@@ -504,7 +507,7 @@ class TimeWaveformFitter(DL0Fitter, Reconstructor):
         """
             Compute quantities used at each iteration of the fitting procedure.
         """
-        #May need rework after accelaration addition
+        # May need rework after accelaration addition
         photoelectron_peak = np.arange(5*n_peaks, dtype=np.int)  # the 5* is more testing only
         self.photo_peaks = photoelectron_peak
         photoelectron_peak = photoelectron_peak[..., None]
@@ -573,12 +576,12 @@ class TimeWaveformFitter(DL0Fitter, Reconstructor):
             it = it + 1
         kmin[kmin<0] = 0
         kmax = np.ceil(kmax)
-        mask = (kmax <= len(self.log_k)/5)  # /5 for testing only
-        if len(kmin[mask])==0 or len(kmax[mask])==0:
-            kmin,kmax=0,len(self.log_k)
+        mask = (kmax <= len(self.log_k) / 5)  # /5 for testing only
+        if len(kmin[mask]) == 0 or len(kmax[mask]) == 0:
+            kmin, kmax = 0, len(self.log_k)
         else:
-            #kmin,kmax = min(kmin[mask].astype(int)),max(kmax[mask].astype(int))
-            kmin,kmax = min(kmin.astype(int)),max(kmax.astype(int))
+            #kmin, kmax = min(kmin[mask].astype(int)), max(kmax[mask].astype(int))
+            kmin, kmax = min(kmin.astype(int)), max(kmax.astype(int))
 
         if kmax > len(self.log_k):
             kmax = len(self.log_k)
@@ -586,7 +589,7 @@ class TimeWaveformFitter(DL0Fitter, Reconstructor):
             # Only usefull to compare the sum with the Gaussian approx.
             # Actual implementation should use n_peak as length and
             # compute only the gaussian approx for higher kmax
-        
+
         log_k = self.log_k
 
         self.photo_peaks = np.arange(kmin, kmax, dtype=np.int)
@@ -599,7 +602,7 @@ class TimeWaveformFitter(DL0Fitter, Reconstructor):
         log_poisson = log_mu - log_k[kmin:kmax][..., None] - x + log_x
 
         mean_LG = self.photo_peaks * ((self.gain[..., None] *
-               self.template(t, gain='LG')))[..., None]
+                                       self.template(t, gain='LG')))[..., None]
 
         mean_HG = self.photo_peaks * ((self.gain[..., None] *
                                        self.template(t, gain='HG')))[
@@ -611,11 +614,11 @@ class TimeWaveformFitter(DL0Fitter, Reconstructor):
         x = self.data - self.baseline[..., None]
 
         sigma_n_LG = self.photo_peaks * ((self.sigma_s[..., None] *
-                  self.template(t, gain='LG')) ** 2)[..., None]
+                                          self.template(t, gain='LG')) ** 2)[..., None]
 
         sigma_n_HG = self.photo_peaks * ((self.sigma_s[..., None] *
-                                       self.template(t, gain='HG')) ** 2)[
-            ..., None]
+                                          self.template(t, gain='HG')) ** 2)[..., None]
+
         sigma_n = sigma_n_HG.T * self.is_high_gain + sigma_n_LG.T * (~self.is_high_gain)
         sigma_n = sigma_n.T
 
@@ -624,17 +627,19 @@ class TimeWaveformFitter(DL0Fitter, Reconstructor):
 
 
         if np.any(~mask):
-            mu_hat_LG = (mu[~mask] / (1-self.crosstalk_factor[~mask]))
-                        * (self.gain[~mask][..., None] * self.template[~mask](t, gain='LG'))
-            mu_hat_HG = (mu[~mask] / (1-self.crosstalk_factor[~mask]))
-                        * (self.gain[~mask][..., None] * self.template[~mask](t, gain='HG'))
-            mu_hat =  (mu_hat_HG.T * self.is_high_gain[~mask]) + mu_hat_LG.T * (~self.is_high_gain[~mask])
+            mu_hat_LG = ((mu[~mask] / (1-self.crosstalk_factor[~mask]))
+                         * (self.gain[~mask][..., None] * self.template[~mask](t, gain='LG')))
+            mu_hat_HG = ((mu[~mask] / (1-self.crosstalk_factor[~mask]))
+                         * (self.gain[~mask][..., None] * self.template[~mask](t, gain='HG')))
+            mu_hat = (mu_hat_HG.T * self.is_high_gain[~mask]) + mu_hat_LG.T * (~self.is_high_gain[~mask])
             mu_hat = mu_hat.T
 
-            sigma_hat_LG = (mu[~mask] / np.power(1-self.crosstalk_factor[~mask],3))
-                           *((self.gain[~mask][..., None] * self.template[~mask](t, gain='LG')) ** 2
-            sigma_hat_HG = (mu[~mask] / np.power(1-self.crosstalk_factor[~mask],3))
-                           *((self.gain[~mask][..., None] * self.template[~mask](t, gain='HG')) ** 2
+            sigma_hat_LG = ((mu[~mask] / np.power(1-self.crosstalk_factor[~mask], 3))
+                            * (self.gain[~mask][..., None]
+                                * self.template[~mask](t, gain='LG')) ** 2)
+            sigma_hat_HG = ((mu[~mask] / np.power(1-self.crosstalk_factor[~mask], 3))
+                            * (self.gain[~mask][..., None]
+                                * self.template[~mask](t, gain='HG')) ** 2)
             sigma_hat = (sigma_hat_HG.T * self.is_high_gain[~mask]) + sigma_hat_LG.T * (~self.is_high_gain[~mask])
             sigma_hat = sigma_hat.T
             sigma_hat = np.sqrt((self.error[~mask]**2)[..., None] + sigma_hat)
@@ -658,8 +663,8 @@ class TimeWaveformFitter(DL0Fitter, Reconstructor):
             pdf2 = pdf2[~mask]
             n_points_LL = pdf2.size
             n_points_HL = log_pdf_HL.size()
-            log_pdf2 = (np.log(pdf2).sum() + log_pdf_HL.sum())
-                       / (n_points_LL + n_points_HL)
+            log_pdf2 = ((np.log(pdf2).sum() + log_pdf_HL.sum())
+                        / (n_points_LL + n_points_HL))
 
 
         mask = (pdf <= 0)


### PR DESCRIPTION
## Description
A Gaussian approximation of the pixel likelihood is added for high luminosity pixels. High luminosity pixels are identified as pixel requiring to consider a number of possible photo-electron above the parameter n_peak in the likelihood computation.

The goal is to reduce the computation time required for such pixels as the range of Poisson contributing terms for the exact likelihood computation increase with the expected signal. It also limits the number of pre-computed factorials required.

WIP : 
- Current implementation (7ff716e)  only used for comparison. The Gaussian approximation is not used for the fitting procedure. Instead, the limit on the maximum value of number of photo-electron for the likelihood sum is increased by a factor 5. The comparison can thus be performed for pixels with n_peak < kmax < 5* n_peak

## Related Issue
Related to #7 


## How Has This Been Tested?
Currently not tested


## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
